### PR TITLE
fix: resolve npm audit vulnerabilities in qs, tmp, ws

### DIFF
--- a/selenium-mcp-server/package-lock.json
+++ b/selenium-mcp-server/package-lock.json
@@ -2191,9 +2191,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2682,9 +2682,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -2911,9 +2911,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

- Transitive lockfile bumps applied by `npm audit fix`:
  - `qs` 6.15.0 → 6.15.2 (moderate — DoS in `qs.stringify`)
  - `tmp` 0.2.5 → 0.2.7 (high — path traversal via prefix/postfix)
  - `ws` 8.19.0 → 8.21.0 (moderate — uninitialized memory disclosure)
- `package.json` untouched; no direct-dependency or source changes.
- Unblocks the Security workflow on `main` (`npm-audit` job is currently failing on `--audit-level=high` due to the `tmp` advisory), which in turn unblocks the 3.2.0 release.

## Test plan

- [ ] `npm run build` passes (verified locally).
- [ ] `npm audit --audit-level=high` reports 0 vulnerabilities (verified locally — was 3, now 0).
- [ ] CI: Security / npm Audit job goes green.
- [ ] No runtime regressions — all three bumps are patch/minor within the same major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)