### PR TITLE
feat: provision matching chromedriver before browser launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,60 @@ jobs:
           timeout 5 node dist/bin/cli.js --help || true
 
   # ============================================
+  # Driver Provisioning (cross-platform, gating)
+  # ============================================
+  driver-provisioning:
+    name: Driver Provisioning (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: build
+    defaults:
+      run:
+        working-directory: selenium-mcp-server
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: selenium-mcp-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Full unit suite — these MUST pass (unlike the lenient `test` job above,
+      # there is no continue-on-error here). The macOS Chrome-detection paths are
+      # exercised on a real macOS runner.
+      - name: Unit tests
+        run: npm test
+
+      # Real end-to-end: detect Chrome, resolve & download a matching chromedriver,
+      # and validate it is an executable (not a .zip). resolveDriver has its own
+      # backoff, so a transient blip is absorbed by the code under test, not masked.
+      - name: Resolve a real chromedriver (end-to-end)
+        shell: bash
+        run: >-
+          node -e "import('./dist/src/driver-provision.js').then(m=>m.resolveDriver()).then(r=>{console.log('resolved:',JSON.stringify(r));process.exit(r.driverPath?0:1)}).catch(e=>{console.error('FAILED:',e.message);process.exit(1)})"
+
+      # Informational: print the doctor report. Non-gating because a fresh runner
+      # may have Chrome outside the standard install path.
+      - name: Doctor report
+        shell: bash
+        continue-on-error: true
+        run: node dist/bin/cli.js doctor
+
+  # ============================================
   # Integration Test with Selenium Grid
   # ============================================
   integration:

--- a/selenium-mcp-server/CHANGELOG.md
+++ b/selenium-mcp-server/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [3.3.0] - 2026-06-19
+
+### New Features
+
+- **Robust driver provisioning** — the matching `chromedriver` is now resolved explicitly *before* the browser launches, instead of implicitly inside Selenium's `.build()`. The server detects the installed Chrome version, reuses a matching cached driver, and only resolves/downloads when the major version no longer matches — then hands the verified path to the `Service` so no unnecessary auto-download is triggered. Nothing is pinned; it tracks Chrome updates automatically. Skippable via `SELENIUM_AI_AGENT_SKIP_PROVISION=1`.
+
+- **Corrupt-cache recovery** — an interrupted download that leaves an unextracted `.zip` or a non-executable file is detected, the single affected cache entry is removed, and resolution is retried with exponential backoff. A `.zip` is never spawned as an executable (fixes `EACCES` / "Exec format error" on first use).
+
+- **Corporate proxy support** — proxy settings are read from one config file (`~/.selenium-ai-agent/config.json`, override via `SELENIUM_AI_AGENT_CONFIG`) and the standard `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` environment variables (env takes precedence). They are injected explicitly into the driver-download subprocess, so resolution works even when a GUI-launched server does not inherit the shell's proxy.
+
+- **`doctor` command** — `npx selenium-ai-agent doctor` runs preflight diagnostics: Chrome presence and version, an executable matching driver, download-endpoint reachability (through the proxy), and the cache location — printing a concrete fix for anything that fails.
+
+### Fixes
+
+- **Driver cache directory on Windows** — Selenium's cache is `~/.cache/selenium` on every platform, not `%LOCALAPPDATA%\selenium`. The start-up preflight now targets the correct directory (the previous path meant cache recovery silently operated on the wrong folder on Windows).
+
+- **`SE_CACHE_PATH`** is now honoured for locating cached drivers, allowing the cache to be moved off a shared/network mount (e.g. a VMware-shared home folder) onto a local disk.
+
 ## [3.1.0] - 2026-03-24
 
 ### Breaking Changes

--- a/selenium-mcp-server/README.md
+++ b/selenium-mcp-server/README.md
@@ -22,7 +22,80 @@ npx selenium-ai-agent
 
 - Node.js 18+
 - Chrome browser (or Firefox/Edge)
-- ChromeDriver is automatically managed by selenium-webdriver
+- ChromeDriver is provisioned automatically — the server detects your installed
+  Chrome version, reuses a matching cached driver, and only downloads a new one
+  when the version no longer matches. Run `npx selenium-ai-agent doctor` to verify.
+
+## Driver Setup, Proxy & Troubleshooting
+
+On first use the server resolves a `chromedriver` that matches your installed
+Chrome. If that fails (corporate proxy, offline, corrupt cache), start here.
+
+### `doctor` — preflight diagnostics
+
+```bash
+npx selenium-ai-agent doctor
+```
+
+From a cloned repo (e.g. when verifying on macOS or Linux):
+
+```bash
+cd selenium-mcp-server
+npm ci && npm run build
+node dist/bin/cli.js doctor
+```
+
+It checks, and prints a concrete fix for anything that fails:
+
+- Chrome is installed and which version,
+- an executable, matching `chromedriver` is cached and ready,
+- the download endpoint is reachable (through your proxy, if configured),
+- where the driver cache lives.
+
+### Corporate proxy
+
+A GUI-launched MCP server does **not** inherit your shell's proxy. Configure it
+explicitly in one place — a JSON file in your home directory:
+
+`~/.selenium-ai-agent/config.json`
+
+```json
+{
+  "proxy": "http://user:pass@proxy.corp:8080",
+  "noProxy": "localhost,127.0.0.1,.internal"
+}
+```
+
+The standard `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` environment variables are
+also honoured and take precedence over the file. The proxy is injected
+explicitly into the driver-download subprocess, so it works even when the parent
+process has no proxy in its environment. (Keep credentials in this home-dir file
+— never commit them.)
+
+### Corrupt or half-extracted cache
+
+A driver download interrupted mid-way can leave an unextracted `.zip` or a
+non-executable file in the cache, causing `EACCES` / "Exec format error". The
+server now detects this, removes just that cache entry, and re-resolves with
+exponential backoff — it never spawns a `.zip` as an executable.
+
+### Shared / network folders (VMware, mapped drives)
+
+The driver cache defaults to `~/.cache/selenium` on every platform (macOS,
+Linux and Windows alike — it is **not** `%LOCALAPPDATA%` on Windows). If your
+home directory is on a shared (VMware/HGFS) or network mount, the OS may refuse
+to execute the driver from there. Point the cache at a local disk:
+
+```bash
+# Windows
+SE_CACHE_PATH=C:\selenium-cache
+# macOS / Linux
+SE_CACHE_PATH=/var/tmp/selenium
+```
+
+> Developing on macOS but running inside a Windows VM with the Mac folders
+> shared in? Keep `SE_CACHE_PATH` on each guest's local disk so the driver is
+> never executed across the share.
 
 ## Quick Start
 
@@ -192,6 +265,13 @@ These clients typically allow you to configure auto-approval per tool or per ser
 | `SELENIUM_MCP_SAVE_TRACE` | `false` | Save session trace JSON to `<output>/traces/` |
 | `SELENIUM_MCP_UNRESTRICTED_FILES` | `false` | Bypass workspace path validation (allow writing outside output dir) |
 | `SE_AVOID_STATS` | — | Set to `true` to disable Selenium usage statistics |
+| `HTTPS_PROXY` / `HTTP_PROXY` | — | Proxy for the driver download (overrides the config file) |
+| `NO_PROXY` | — | Comma-separated hosts that bypass the proxy |
+| `SE_CACHE_PATH` | `~/.cache/selenium` | Driver cache directory — point at a local disk when home is a shared/network folder |
+| `SELENIUM_AI_AGENT_CONFIG` | `~/.selenium-ai-agent/config.json` | Override path to the proxy config file |
+| `SELENIUM_AI_AGENT_SKIP_PROVISION` | — | Set to `1` to skip driver provisioning and let Selenium resolve the driver itself |
+| `SELENIUM_AI_AGENT_SKIP_PREFLIGHT` | — | Set to `1` to skip the start-up driver check |
+| `SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS` | `30000` | Timeout for the start-up driver check |
 
 Pass env vars in your MCP config:
 
@@ -215,10 +295,12 @@ Pass env vars in your MCP config:
 
 ```bash
 npx selenium-ai-agent [flags]
+npx selenium-ai-agent doctor   # run driver/proxy diagnostics and exit
 ```
 
 | Flag | Description |
 |------|-------------|
+| `doctor` | Run preflight diagnostics (Chrome, driver, proxy, cache) and exit |
 | `--stealth` | Enable stealth mode |
 | `--headless` | Run browser headless |
 | `--save-trace` | Save session trace JSON |

--- a/selenium-mcp-server/bin/cli.ts
+++ b/selenium-mcp-server/bin/cli.ts
@@ -11,6 +11,13 @@ if (args[0] === 'install') {
   process.exit(0);
 }
 
+if (args[0] === 'doctor') {
+  const { runDoctor, formatDoctorReport } = await import('../src/doctor.js');
+  const report = await runDoctor();
+  console.log(formatDoctorReport(report));
+  process.exit(report.ok ? 0 : 1);
+}
+
 let transport = 'stdio';
 let port = 3000;
 

--- a/selenium-mcp-server/package-lock.json
+++ b/selenium-mcp-server/package-lock.json
@@ -41,9 +41,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1231,32 +1231,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -1634,9 +1634,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1795,10 +1795,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/selenium-mcp-server/package-lock.json
+++ b/selenium-mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "selenium-ai-agent",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "selenium-ai-agent",
-      "version": "3.3.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/selenium-mcp-server/package-lock.json
+++ b/selenium-mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "selenium-ai-agent",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "selenium-ai-agent",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/selenium-mcp-server/package.json
+++ b/selenium-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selenium-ai-agent",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "AI-powered Selenium MCP server for browser automation — 74 tools with accessibility tree discovery, test generation, self-healing, and Selenium Grid parallel execution for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/selenium-mcp-server/package.json
+++ b/selenium-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selenium-ai-agent",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "description": "AI-powered Selenium MCP server for browser automation — 74 tools with accessibility tree discovery, test generation, self-healing, and Selenium Grid parallel execution for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/selenium-mcp-server/src/context.ts
+++ b/selenium-mcp-server/src/context.ts
@@ -1,10 +1,12 @@
 import { Builder, WebDriver, WebElement } from 'selenium-webdriver';
+import chrome from 'selenium-webdriver/chrome.js';
 import { PageSnapshot, BrowserConfig, TabInfo, ConsoleLogEntry, SnapshotOptions, ConsoleOptions, DiffOptions } from './types.js';
 import { discoverElements, findElementByInfo, formatAccessibilityTree } from './utils/element-discovery/index.js';
 import { buildChromeOptions, applyStealthScripts } from './utils/chrome-options.js';
 import { EventCollector } from './bidi/event-collector.js';
 import { SessionTracer } from './trace/session-tracer.js';
 import { wrapDriverError } from './driver-errors.js';
+import { resolveDriver } from './driver-provision.js';
 
 // Forward-declared types for grid support — modules loaded dynamically via ensureGrid()
 import type { SessionPool } from './grid/session-pool.js';
@@ -284,6 +286,20 @@ export class Context {
       return this.activeGridSession.getDriver();
     }
     if (!this.driver) {
+      // Provision a verified chromedriver up-front so Selenium's .build() reuses
+      // it instead of triggering a proxy-blind auto-download. Set
+      // SELENIUM_AI_AGENT_SKIP_PROVISION=1 to fall back to Selenium's own
+      // resolution (e.g. when managing the driver manually).
+      let service: chrome.ServiceBuilder | undefined;
+      if (process.env.SELENIUM_AI_AGENT_SKIP_PROVISION !== '1') {
+        try {
+          const { driverPath } = await resolveDriver();
+          service = new chrome.ServiceBuilder(driverPath);
+        } catch (err) {
+          throw wrapDriverError(err, 'local');
+        }
+      }
+
       if (this.isAttachMode()) {
         // Attach to an already-running Chromium over CDP instead of launching one.
         // Empirically validated on chromedriver 148: BiDi negotiates on attach, so
@@ -301,6 +317,7 @@ export class Context {
               windowTypes: ['page', 'webview'],
             },
           });
+        if (service) builder.setChromeService(service);
         try {
           this.driver = await builder.build();
         } catch (err) {
@@ -316,6 +333,8 @@ export class Context {
         const builder = new Builder()
           .forBrowser('chrome')
           .setChromeOptions(options);
+
+        if (service) builder.setChromeService(service);
 
         // Always enable BiDi WebSocket — needed for stealth, screenshots, PDF, event collection
         builder.withCapabilities({ webSocketUrl: true });

--- a/selenium-mcp-server/src/doctor.test.ts
+++ b/selenium-mcp-server/src/doctor.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import { runDoctor, formatDoctorReport, type DoctorDeps } from './doctor.js';
+
+describe('doctor', () => {
+  const happy: Partial<DoctorDeps> = {
+    detectChrome: () => ({ version: '149.0.7827.155', major: 149 }),
+    findCached: () => '/cache/chromedriver/win64/149.0.7827.155/chromedriver.exe',
+    probe: async () => true,
+    proxy: undefined,
+    cacheDir: '/home/u/.cache/selenium',
+  };
+
+  it('should pass every check when Chrome, driver and network are healthy', async () => {
+    const report = await runDoctor(happy);
+    expect(report.ok).to.equal(true);
+    expect(report.checks.find((c) => c.name === 'Chrome installed')!.ok).to.equal(true);
+  });
+
+  it('should fail the Chrome check with a fix when Chrome is absent', async () => {
+    const report = await runDoctor({ ...happy, detectChrome: () => null });
+    const chrome = report.checks.find((c) => c.name === 'Chrome installed')!;
+    expect(chrome.ok).to.equal(false);
+    expect(chrome.fix).to.be.a('string');
+    expect(report.ok).to.equal(false);
+  });
+
+  it('should fail the driver check when no matching cached driver exists', async () => {
+    const report = await runDoctor({ ...happy, findCached: () => null });
+    const driver = report.checks.find((c) => c.name === 'Matching driver ready')!;
+    expect(driver.ok).to.equal(false);
+    expect(driver.fix).to.include('SE_CACHE_PATH');
+  });
+
+  it('should report proxy reachability when a proxy is configured', async () => {
+    const report = await runDoctor({ ...happy, proxy: 'http://proxy.corp:8080', probe: async () => true });
+    const endpoint = report.checks.find((c) => c.name === 'Download endpoint reachable')!;
+    expect(endpoint.ok).to.equal(true);
+    expect(endpoint.detail).to.include('proxy.corp:8080');
+  });
+
+  it('should fail the endpoint check when the proxy is unreachable', async () => {
+    const report = await runDoctor({ ...happy, proxy: 'http://proxy.corp:8080', probe: async () => false });
+    const endpoint = report.checks.find((c) => c.name === 'Download endpoint reachable')!;
+    expect(endpoint.ok).to.equal(false);
+    expect(endpoint.fix).to.be.a('string');
+  });
+
+  it('should flag a malformed proxy URL', async () => {
+    const report = await runDoctor({ ...happy, proxy: 'not a url', probe: async () => true });
+    const endpoint = report.checks.find((c) => c.name === 'Download endpoint reachable')!;
+    expect(endpoint.ok).to.equal(false);
+    expect(endpoint.detail).to.include('not a valid URL');
+  });
+
+  it('should render an actionable report with [X] and fix lines on failure', () => {
+    const text = formatDoctorReport({
+      ok: false,
+      checks: [
+        { name: 'Chrome installed', ok: false, detail: 'not found', fix: 'install Chrome' },
+        { name: 'Driver cache location', ok: true, detail: '/cache' },
+      ],
+    });
+    expect(text).to.include('[X]  Chrome installed');
+    expect(text).to.include('fix: install Chrome');
+    expect(text).to.include('Some checks failed');
+  });
+});

--- a/selenium-mcp-server/src/doctor.ts
+++ b/selenium-mcp-server/src/doctor.ts
@@ -1,0 +1,196 @@
+import net from 'node:net';
+import { existsSync } from 'node:fs';
+import {
+  detectChromeVersion,
+  findCachedDriver,
+  getSeleniumCacheDir,
+  type ChromeInfo,
+} from './driver-provision.js';
+import { loadProxyConfig } from './proxy-config.js';
+
+/** Result of a single doctor check. */
+export interface DoctorCheck {
+  readonly name: string;
+  readonly ok: boolean;
+  readonly detail: string;
+  /** Concrete, copy-pasteable next step when the check fails. */
+  readonly fix?: string;
+}
+
+export interface DoctorReport {
+  readonly checks: readonly DoctorCheck[];
+  readonly ok: boolean;
+}
+
+/** Dependencies of runDoctor, injectable for testing. */
+export interface DoctorDeps {
+  detectChrome: () => ChromeInfo | null;
+  findCached: (major: number) => string | null;
+  probe: (host: string, port: number, timeoutMs: number) => Promise<boolean>;
+  proxy?: string;
+  cacheDir: string;
+}
+
+/** Raw TCP reachability probe — dependency-free, honours no proxy itself. */
+export function tcpProbe(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const finish = (ok: boolean): void => {
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+    socket.connect(port, host);
+  });
+}
+
+function checkChrome(chrome: ChromeInfo | null): DoctorCheck {
+  if (!chrome) {
+    return {
+      name: 'Chrome installed',
+      ok: false,
+      detail: 'Google Chrome could not be detected',
+      fix: 'Install Google Chrome, or ensure it is on PATH (Linux) / in the standard location.',
+    };
+  }
+  return {
+    name: 'Chrome installed',
+    ok: true,
+    detail: `Chrome ${chrome.version} (major ${chrome.major})`,
+  };
+}
+
+function checkDriver(chrome: ChromeInfo | null, findCached: (major: number) => string | null): DoctorCheck {
+  if (!chrome) {
+    return {
+      name: 'Matching driver ready',
+      ok: false,
+      detail: 'skipped — Chrome version unknown',
+      fix: 'Resolve the Chrome check first.',
+    };
+  }
+  const driver = findCached(chrome.major);
+  if (driver) {
+    return {
+      name: 'Matching driver ready',
+      ok: true,
+      detail: `executable chromedriver for Chrome ${chrome.major}: ${driver}`,
+    };
+  }
+  return {
+    name: 'Matching driver ready',
+    ok: false,
+    detail: `no valid cached chromedriver for Chrome ${chrome.major}`,
+    fix: 'Start the server once with network access to download it, or run the diagnostic command. '
+      + 'If your home/cache is on a shared (VMware/network) folder, point SE_CACHE_PATH at a local disk.',
+  };
+}
+
+async function checkEndpoint(
+  proxy: string | undefined,
+  probe: (host: string, port: number, timeoutMs: number) => Promise<boolean>,
+): Promise<DoctorCheck> {
+  const TIMEOUT = 5_000;
+
+  if (proxy) {
+    let host: string;
+    let port: number;
+    try {
+      const url = new URL(proxy);
+      host = url.hostname;
+      port = url.port ? parseInt(url.port, 10) : url.protocol === 'https:' ? 443 : 80;
+    } catch {
+      return {
+        name: 'Download endpoint reachable',
+        ok: false,
+        detail: `configured proxy is not a valid URL: ${proxy}`,
+        fix: 'Fix the proxy URL in ~/.selenium-ai-agent/config.json or the HTTPS_PROXY env var.',
+      };
+    }
+    const ok = await probe(host, port, TIMEOUT);
+    return ok
+      ? { name: 'Download endpoint reachable', ok: true, detail: `proxy ${host}:${port} reachable` }
+      : {
+          name: 'Download endpoint reachable',
+          ok: false,
+          detail: `proxy ${host}:${port} is NOT reachable`,
+          fix: 'Check the proxy host/port and that the VPN is connected.',
+        };
+  }
+
+  const endpoints: ReadonlyArray<readonly [string, number]> = [
+    ['googlechromelabs.github.io', 443],
+    ['storage.googleapis.com', 443],
+  ];
+  const results = await Promise.all(endpoints.map(([h, p]) => probe(h, p, TIMEOUT)));
+  const unreachable = endpoints.filter((_, i) => !results[i]).map(([h]) => h);
+
+  if (unreachable.length === 0) {
+    return {
+      name: 'Download endpoint reachable',
+      ok: true,
+      detail: 'googlechromelabs.github.io and storage.googleapis.com reachable',
+    };
+  }
+  return {
+    name: 'Download endpoint reachable',
+    ok: false,
+    detail: `unreachable: ${unreachable.join(', ')}`,
+    fix: 'Behind a corporate proxy? Set "proxy" in ~/.selenium-ai-agent/config.json or the HTTPS_PROXY env var.',
+  };
+}
+
+function checkCache(cacheDir: string): DoctorCheck {
+  const present = existsSync(cacheDir);
+  return {
+    name: 'Driver cache location',
+    ok: true,
+    detail: present ? `${cacheDir} (exists)` : `${cacheDir} (will be created on first run)`,
+  };
+}
+
+function defaultDeps(): DoctorDeps {
+  return {
+    detectChrome: detectChromeVersion,
+    findCached: (major) => findCachedDriver(major),
+    probe: tcpProbe,
+    proxy: loadProxyConfig().proxy,
+    cacheDir: getSeleniumCacheDir(),
+  };
+}
+
+/**
+ * Run all preflight diagnostics. Each check carries a concrete fix on failure.
+ * Never throws — a failed probe becomes a failed check.
+ */
+export async function runDoctor(deps: Partial<DoctorDeps> = {}): Promise<DoctorReport> {
+  const d: DoctorDeps = { ...defaultDeps(), ...deps };
+
+  const chrome = d.detectChrome();
+  const checks: DoctorCheck[] = [
+    checkChrome(chrome),
+    checkDriver(chrome, d.findCached),
+    await checkEndpoint(d.proxy, d.probe),
+    checkCache(d.cacheDir),
+  ];
+
+  return { checks, ok: checks.every((c) => c.ok) };
+}
+
+/** Render a report as a human-readable, 80-column-friendly block. */
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines: string[] = ['Selenium AI Agent — doctor', ''];
+  for (const check of report.checks) {
+    lines.push(`${check.ok ? '[OK]' : '[X] '} ${check.name}`);
+    lines.push(`     ${check.detail}`);
+    if (!check.ok && check.fix) {
+      lines.push(`     fix: ${check.fix}`);
+    }
+  }
+  lines.push('');
+  lines.push(report.ok ? 'All checks passed.' : 'Some checks failed — see the fixes above.');
+  return lines.join('\n');
+}

--- a/selenium-mcp-server/src/driver-provision.test.ts
+++ b/selenium-mcp-server/src/driver-provision.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'node:fs';
+import os from 'node:os';
+import childProcess from 'node:child_process';
+
+import {
+  extractVersion,
+  parseMajor,
+  compareVersions,
+  isValidDriverBinary,
+  findCachedDriver,
+  getSeleniumCacheDir,
+  detectChromeVersion,
+  resolveDriver,
+  type ResolveDeps,
+  type ChromeInfo,
+} from './driver-provision.js';
+
+describe('driver-provision', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('extractVersion', () => {
+    it('should extract a full version from Selenium Manager text', () => {
+      expect(extractVersion('Driver path: .../149.0.7827.155/chromedriver.exe')).to.equal('149.0.7827.155');
+    });
+
+    it('should extract a version from "Google Chrome 138.0.7204.49"', () => {
+      expect(extractVersion('Google Chrome 138.0.7204.49 ')).to.equal('138.0.7204.49');
+    });
+
+    it('should return null when no version is present', () => {
+      expect(extractVersion('no version here')).to.equal(null);
+    });
+  });
+
+  describe('parseMajor', () => {
+    it('should parse the major version from a full version', () => {
+      expect(parseMajor('149.0.7827.155')).to.equal(149);
+    });
+
+    it('should return null for a non-numeric string', () => {
+      expect(parseMajor('vNext')).to.equal(null);
+    });
+  });
+
+  describe('compareVersions', () => {
+    it('should order by numeric patch, not lexicographically', () => {
+      // "149.0.7827.9" < "149.0.7827.20" numerically, but > lexicographically
+      expect(compareVersions('149.0.7827.9', '149.0.7827.20')).to.be.lessThan(0);
+    });
+
+    it('should return 0 for equal versions', () => {
+      expect(compareVersions('149.0.1.2', '149.0.1.2')).to.equal(0);
+    });
+  });
+
+  describe('isValidDriverBinary', () => {
+    let existsStub: sinon.SinonStub;
+    let statStub: sinon.SinonStub;
+    let platformStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      existsStub = sinon.stub(fs, 'existsSync').returns(true);
+      statStub = sinon.stub(fs, 'statSync');
+      platformStub = sinon.stub(os, 'platform').returns('linux');
+    });
+
+    function fakeStat(overrides: Partial<{ isFile: boolean; size: number; mode: number }>): unknown {
+      return {
+        isFile: () => overrides.isFile ?? true,
+        size: overrides.size ?? 1000,
+        mode: overrides.mode ?? 0o755,
+      };
+    }
+
+    it('should reject a .zip path without touching the filesystem', () => {
+      const result = isValidDriverBinary('/cache/chromedriver/linux64/149.0.0.0/chromedriver.zip');
+      expect(result).to.equal(false);
+    });
+
+    it('should reject a path that does not exist', () => {
+      existsStub.returns(false);
+      expect(isValidDriverBinary('/cache/.../chromedriver')).to.equal(false);
+    });
+
+    it('should reject a zero-byte file', () => {
+      statStub.returns(fakeStat({ size: 0 }));
+      expect(isValidDriverBinary('/cache/.../chromedriver')).to.equal(false);
+    });
+
+    it('should reject a non-executable file on POSIX', () => {
+      statStub.returns(fakeStat({ mode: 0o644 }));
+      expect(isValidDriverBinary('/cache/.../chromedriver')).to.equal(false);
+    });
+
+    it('should accept an executable file on POSIX', () => {
+      statStub.returns(fakeStat({ mode: 0o755 }));
+      expect(isValidDriverBinary('/cache/.../chromedriver')).to.equal(true);
+    });
+
+    it('should require an .exe extension on Windows', () => {
+      platformStub.returns('win32');
+      statStub.returns(fakeStat({ mode: 0o644 }));
+      expect(isValidDriverBinary('C:\\cache\\chromedriver')).to.equal(false);
+      expect(isValidDriverBinary('C:\\cache\\chromedriver.exe')).to.equal(true);
+    });
+  });
+
+  describe('detectChromeVersion', () => {
+    let execStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      execStub = sinon.stub(childProcess, 'execFileSync');
+      sinon.stub(os, 'homedir').returns('/Users/tester');
+    });
+
+    it('should detect Chrome on macOS from the standard Applications path', () => {
+      sinon.stub(os, 'platform').returns('darwin');
+      execStub.returns('Google Chrome 150.0.1.2 \n');
+
+      const info = detectChromeVersion();
+      expect(info).to.not.equal(null);
+      expect(info!.version).to.equal('150.0.1.2');
+      expect(info!.major).to.equal(150);
+    });
+
+    it('should fall back to ~/Applications on macOS when the system path fails', () => {
+      sinon.stub(os, 'platform').returns('darwin');
+      execStub.onFirstCall().throws(new Error('ENOENT'));
+      execStub.onSecondCall().returns('Google Chrome 151.0.0.0');
+
+      const info = detectChromeVersion();
+      expect(info!.major).to.equal(151);
+      const homeArg = (execStub.secondCall.args[0] as string).replace(/\\/g, '/');
+      expect(homeArg).to.include('/Users/tester/Applications');
+    });
+
+    it('should return null on macOS when Chrome is not found anywhere', () => {
+      sinon.stub(os, 'platform').returns('darwin');
+      execStub.throws(new Error('ENOENT'));
+
+      expect(detectChromeVersion()).to.equal(null);
+    });
+  });
+
+  describe('getSeleniumCacheDir', () => {
+    it('should default to ~/.cache/selenium on all platforms', () => {
+      sinon.stub(os, 'homedir').returns('/home/testuser');
+      const dir = getSeleniumCacheDir({}).replace(/\\/g, '/');
+      expect(dir).to.equal('/home/testuser/.cache/selenium');
+    });
+
+    it('should honour SE_CACHE_PATH', () => {
+      expect(getSeleniumCacheDir({ SE_CACHE_PATH: '/custom/cache' })).to.equal('/custom/cache');
+    });
+  });
+
+  describe('findCachedDriver', () => {
+    let existsStub: sinon.SinonStub;
+    let readdirStub: sinon.SinonStub;
+    let statStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      sinon.stub(os, 'platform').returns('linux');
+      existsStub = sinon.stub(fs, 'existsSync').returns(true);
+      readdirStub = sinon.stub(fs, 'readdirSync');
+      statStub = sinon.stub(fs, 'statSync').returns({
+        isFile: () => true,
+        size: 1000,
+        mode: 0o755,
+      } as unknown as fs.Stats);
+    });
+
+    it('should return a cached driver whose major version matches', () => {
+      readdirStub.withArgs(sinon.match(/chromedriver$/)).returns(['linux64']);
+      readdirStub.withArgs(sinon.match(/linux64$/)).returns(['149.0.7827.155']);
+
+      const result = findCachedDriver(149, '/cache');
+      expect(result).to.be.a('string');
+      expect(result!.replace(/\\/g, '/')).to.include('149.0.7827.155/chromedriver');
+    });
+
+    it('should return null when no cached version matches the major', () => {
+      readdirStub.withArgs(sinon.match(/chromedriver$/)).returns(['linux64']);
+      readdirStub.withArgs(sinon.match(/linux64$/)).returns(['148.0.7777.0']);
+
+      expect(findCachedDriver(149, '/cache')).to.equal(null);
+    });
+
+    it('should prefer the highest patch version for the major', () => {
+      readdirStub.withArgs(sinon.match(/chromedriver$/)).returns(['linux64']);
+      readdirStub.withArgs(sinon.match(/linux64$/)).returns(['149.0.7827.9', '149.0.7827.155']);
+
+      const result = findCachedDriver(149, '/cache')!.replace(/\\/g, '/');
+      expect(result).to.include('149.0.7827.155/chromedriver');
+    });
+
+    it('should return null when the cache root does not exist', () => {
+      existsStub.returns(false);
+      expect(findCachedDriver(149, '/cache')).to.equal(null);
+    });
+  });
+
+  describe('resolveDriver', () => {
+    const chrome: ChromeInfo = { version: '149.0.7827.155', major: 149 };
+
+    function baseDeps(over: Partial<ResolveDeps>): Partial<ResolveDeps> {
+      return {
+        detectChrome: () => chrome,
+        findCached: () => null,
+        runManager: () => '/cache/chromedriver/linux64/149.0.7827.155/chromedriver',
+        validate: () => true,
+        removeEntry: () => undefined,
+        sleep: async () => undefined,
+        ...over,
+      };
+    }
+
+    it('should reuse a cached driver without invoking Selenium Manager', async () => {
+      const runManager = sinon.stub().throws(new Error('should not be called'));
+      const result = await resolveDriver({}, baseDeps({
+        findCached: () => '/cache/chromedriver/linux64/149.0.7827.155/chromedriver',
+        runManager,
+      }));
+
+      expect(result.fromCache).to.equal(true);
+      expect(runManager.called).to.equal(false);
+    });
+
+    it('should resolve via Selenium Manager when no cache match exists', async () => {
+      const result = await resolveDriver({}, baseDeps({}));
+      expect(result.fromCache).to.equal(false);
+      expect(result.driverPath).to.include('chromedriver');
+    });
+
+    it('should repair a corrupt entry and retry', async () => {
+      const removeEntry = sinon.stub();
+      const validate = sinon.stub();
+      validate.onFirstCall().returns(false); // corrupt
+      validate.onSecondCall().returns(true); // good after repair
+
+      const result = await resolveDriver({ baseDelayMs: 0 }, baseDeps({
+        validate,
+        removeEntry,
+      }));
+
+      expect(removeEntry.calledOnce).to.equal(true);
+      expect(result.fromCache).to.equal(false);
+    });
+
+    it('should retry transient download failures with backoff', async () => {
+      const sleep = sinon.stub().resolves();
+      const runManager = sinon.stub();
+      runManager.onFirstCall().throws(new Error('error sending request for url'));
+      runManager.onSecondCall().returns('/cache/chromedriver/linux64/149.0.7827.155/chromedriver');
+
+      const result = await resolveDriver({ baseDelayMs: 10 }, baseDeps({ runManager, sleep }));
+
+      expect(runManager.calledTwice).to.equal(true);
+      expect(sleep.calledOnce).to.equal(true);
+      expect(result.driverPath).to.include('chromedriver');
+    });
+
+    it('should throw a clear error after exhausting retries', async () => {
+      const runManager = sinon.stub().throws(new Error('no route to host'));
+
+      let thrown: Error | null = null;
+      try {
+        await resolveDriver({ maxRetries: 2, baseDelayMs: 0 }, baseDeps({ runManager }));
+      } catch (err) {
+        thrown = err as Error;
+      }
+
+      expect(thrown).to.not.equal(null);
+      expect(thrown!.message).to.include('failed after 2 attempt');
+      expect(runManager.calledTwice).to.equal(true);
+    });
+  });
+});

--- a/selenium-mcp-server/src/driver-provision.ts
+++ b/selenium-mcp-server/src/driver-provision.ts
@@ -1,0 +1,381 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, statSync, readdirSync, rmSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { homedir, platform } from 'node:os';
+import { loadProxyConfig, buildSubprocessEnv } from './proxy-config.js';
+
+/** Installed Chrome browser, as far as it could be detected. */
+export interface ChromeInfo {
+  /** Full version string, e.g. "149.0.7827.155". */
+  readonly version: string;
+  /** Major version, e.g. 149. */
+  readonly major: number;
+}
+
+/** Outcome of resolving a usable chromedriver. */
+export interface DriverResolution {
+  /** Absolute path to a validated, executable chromedriver. */
+  readonly driverPath: string;
+  /** True when reused from the cache without invoking Selenium Manager. */
+  readonly fromCache: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Version parsing helpers (pure — the unit-tested core of the match logic)
+// ---------------------------------------------------------------------------
+
+/** Extract the first dotted version (e.g. "149.0.7827.155") from arbitrary text. */
+export function extractVersion(text: string): string | null {
+  const match = text.match(/(\d+(?:\.\d+){1,3})/);
+  return match ? match[1] : null;
+}
+
+/** Parse the leading major-version integer from a version string. */
+export function parseMajor(version: string): number | null {
+  const match = version.match(/^\s*(\d+)/);
+  if (!match) return null;
+  const major = parseInt(match[1], 10);
+  return Number.isNaN(major) ? null : major;
+}
+
+/** Compare two dotted version strings numerically. Returns <0, 0 or >0. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Cache + binary validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Selenium's driver cache. Selenium Manager defaults to ~/.cache/selenium on
+ * EVERY platform (including Windows — it is NOT %LOCALAPPDATA%), overridable
+ * via SE_CACHE_PATH.
+ */
+export function getSeleniumCacheDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.SE_CACHE_PATH?.trim();
+  if (override) return override;
+  return join(homedir(), '.cache', 'selenium');
+}
+
+/** Platform-specific chromedriver executable name. */
+function driverExeName(): string {
+  return platform() === 'win32' ? 'chromedriver.exe' : 'chromedriver';
+}
+
+/**
+ * Validate that a path is a real, runnable chromedriver — NOT an unextracted
+ * .zip or a zero-byte / non-executable file. This is the guard that prevents
+ * spawning a .zip as an executable (the EACCES / "Exec format error" failure).
+ */
+export function isValidDriverBinary(path: string): boolean {
+  if (!path) return false;
+  if (path.toLowerCase().endsWith('.zip')) return false;
+  if (!existsSync(path)) return false;
+
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch {
+    return false;
+  }
+
+  if (!stat.isFile() || stat.size === 0) return false;
+
+  if (platform() === 'win32') {
+    // On Windows executability is by extension; a real driver is an .exe.
+    return path.toLowerCase().endsWith('.exe');
+  }
+
+  // On POSIX require at least one executable bit.
+  const EXECUTABLE_BITS = 0o111;
+  return (stat.mode & EXECUTABLE_BITS) !== 0;
+}
+
+/**
+ * Find a cached chromedriver whose major version matches the installed Chrome.
+ * Cache layout: <cache>/chromedriver/<platform>/<version>/chromedriver[.exe].
+ * Returns the highest matching patch version, or null when none is valid.
+ */
+export function findCachedDriver(
+  major: number,
+  cacheDir: string = getSeleniumCacheDir(),
+): string | null {
+  const driverRoot = join(cacheDir, 'chromedriver');
+  if (!existsSync(driverRoot)) return null;
+
+  const exe = driverExeName();
+  let platformDirs: string[];
+  try {
+    platformDirs = readdirSync(driverRoot);
+  } catch {
+    return null;
+  }
+
+  const candidates: Array<{ version: string; path: string }> = [];
+  for (const platDir of platformDirs) {
+    const platPath = join(driverRoot, platDir);
+    let versions: string[];
+    try {
+      versions = readdirSync(platPath);
+    } catch {
+      continue;
+    }
+    for (const version of versions) {
+      if (parseMajor(version) !== major) continue;
+      const candidate = join(platPath, version, exe);
+      if (isValidDriverBinary(candidate)) {
+        candidates.push({ version, path: candidate });
+      }
+    }
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareVersions(b.version, a.version));
+  return candidates[0].path;
+}
+
+/**
+ * Remove the single cache entry (the <version> directory) that holds the given
+ * driver path. Targeted repair — never wipes the whole cache.
+ */
+export function removeCacheEntry(driverPath: string): void {
+  // driverPath = <cache>/chromedriver/<platform>/<version>/chromedriver[.exe]
+  const versionDir = dirname(driverPath);
+  if (existsSync(versionDir)) {
+    rmSync(versionDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Selenium Manager invocation
+// ---------------------------------------------------------------------------
+
+/** Locate the bundled Selenium Manager binary inside selenium-webdriver. */
+export function getSeleniumManagerPath(): string {
+  const plat = platform();
+  let relative: string;
+  switch (plat) {
+    case 'darwin':
+      relative = 'bin/macos/selenium-manager';
+      break;
+    case 'win32':
+      relative = 'bin/windows/selenium-manager.exe';
+      break;
+    default:
+      relative = 'bin/linux/selenium-manager';
+      break;
+  }
+
+  try {
+    const resolved = join(resolve('node_modules', 'selenium-webdriver'), relative);
+    if (existsSync(resolved)) return resolved;
+  } catch {
+    /* fall through */
+  }
+  return join(process.cwd(), 'node_modules', 'selenium-webdriver', relative);
+}
+
+interface ManagerOutput {
+  readonly result?: { readonly driver_path?: string };
+}
+
+/**
+ * Run Selenium Manager to resolve (and if needed download) the chromedriver.
+ * Returns the reported driver_path. Throws with the captured stderr on failure.
+ */
+function runManager(env: NodeJS.ProcessEnv, timeoutMs: number): string {
+  const binary = getSeleniumManagerPath();
+  if (!existsSync(binary)) {
+    throw new Error(`Selenium Manager binary not found at: ${binary}`);
+  }
+
+  let stdout: string;
+  try {
+    stdout = execFileSync(binary, ['--browser', 'chrome', '--output', 'json'], {
+      env,
+      timeout: timeoutMs,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: unknown) {
+    const stderr = (err as { stderr?: string }).stderr || '';
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(stderr || message);
+  }
+
+  let parsed: ManagerOutput;
+  try {
+    parsed = JSON.parse(stdout) as ManagerOutput;
+  } catch {
+    throw new Error(`could not parse Selenium Manager output: ${stdout.slice(0, 200)}`);
+  }
+
+  const driverPath = parsed.result?.driver_path;
+  if (!driverPath) {
+    throw new Error('Selenium Manager returned no driver_path');
+  }
+  return driverPath;
+}
+
+// ---------------------------------------------------------------------------
+// Chrome detection
+// ---------------------------------------------------------------------------
+
+/** Try a command and return its trimmed stdout, or null if it fails. */
+function tryCommand(cmd: string, args: readonly string[]): string | null {
+  try {
+    return execFileSync(cmd, args as string[], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect the installed Chrome version without touching the network, so the
+ * cache shortcut can run before any Selenium Manager invocation. Returns null
+ * when Chrome cannot be located — callers then fall back to full resolution.
+ */
+export function detectChromeVersion(): ChromeInfo | null {
+  const plat = platform();
+  let raw: string | null = null;
+
+  if (plat === 'win32') {
+    // Registry BLBeacon holds the live version; HKCU first, then HKLM (incl. WOW6432).
+    const keys = [
+      'HKCU\\Software\\Google\\Chrome\\BLBeacon',
+      'HKLM\\SOFTWARE\\Google\\Chrome\\BLBeacon',
+      'HKLM\\SOFTWARE\\WOW6432Node\\Google\\Chrome\\BLBeacon',
+    ];
+    for (const key of keys) {
+      raw = tryCommand('reg', ['query', key, '/v', 'version']);
+      if (raw && extractVersion(raw)) break;
+    }
+  } else if (plat === 'darwin') {
+    // Chrome may live in the system or the per-user Applications folder; both
+    // are common (the latter when installed without admin rights).
+    const macCandidates = [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      join(homedir(), 'Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
+    ];
+    for (const bin of macCandidates) {
+      raw = tryCommand(bin, ['--version']);
+      if (raw && extractVersion(raw)) break;
+    }
+  } else {
+    for (const bin of ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser']) {
+      raw = tryCommand(bin, ['--version']);
+      if (raw && extractVersion(raw)) break;
+    }
+  }
+
+  if (!raw) return null;
+  const version = extractVersion(raw);
+  if (!version) return null;
+  const major = parseMajor(version);
+  if (major === null) return null;
+  return { version, major };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/** Dependencies of resolveDriver, injectable for testing. */
+export interface ResolveDeps {
+  detectChrome: () => ChromeInfo | null;
+  findCached: (major: number) => string | null;
+  runManager: (env: NodeJS.ProcessEnv) => string;
+  validate: (path: string) => boolean;
+  removeEntry: (path: string) => void;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export interface ResolveOptions {
+  readonly maxRetries?: number;
+  readonly baseDelayMs?: number;
+  readonly timeoutMs?: number;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+function defaultDeps(timeoutMs: number): ResolveDeps {
+  return {
+    detectChrome: detectChromeVersion,
+    findCached: (major) => findCachedDriver(major),
+    runManager: (env) => runManager(env, timeoutMs),
+    validate: isValidDriverBinary,
+    removeEntry: removeCacheEntry,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  };
+}
+
+/**
+ * Resolve a usable chromedriver, preferring a cached match for the installed
+ * Chrome version and only invoking Selenium Manager when needed. Corrupt cache
+ * entries are repaired in place; transient download failures are retried with
+ * exponential backoff.
+ *
+ * @throws when no valid driver could be produced after all retries.
+ */
+export async function resolveDriver(
+  options: ResolveOptions = {},
+  deps: Partial<ResolveDeps> = {},
+): Promise<DriverResolution> {
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const d: ResolveDeps = { ...defaultDeps(timeoutMs), ...deps };
+  const maxRetries = options.maxRetries ?? 3;
+  const baseDelay = options.baseDelayMs ?? 500;
+  const env = options.env ?? buildSubprocessEnv(process.env, loadProxyConfig());
+
+  // 1. Reuse a cached driver that matches the installed Chrome major version.
+  const chrome = d.detectChrome();
+  if (chrome) {
+    const cached = d.findCached(chrome.major);
+    if (cached) {
+      return { driverPath: cached, fromCache: true };
+    }
+  }
+
+  // 2. Resolve via Selenium Manager, with backoff + targeted corrupt-cache repair.
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    if (attempt > 0) {
+      await d.sleep(baseDelay * 2 ** (attempt - 1));
+    }
+
+    let driverPath: string;
+    try {
+      driverPath = d.runManager(env);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      continue;
+    }
+
+    if (d.validate(driverPath)) {
+      return { driverPath, fromCache: false };
+    }
+
+    // Corrupt entry (unextracted .zip / non-executable): remove it and retry.
+    lastError = new Error(`resolved driver is not a valid executable: ${driverPath}`);
+    try {
+      d.removeEntry(driverPath);
+    } catch {
+      /* best effort */
+    }
+  }
+
+  throw new Error(
+    `driver resolution failed after ${maxRetries} attempt(s): ${lastError?.message ?? 'unknown error'}`,
+  );
+}

--- a/selenium-mcp-server/src/preflight.test.ts
+++ b/selenium-mcp-server/src/preflight.test.ts
@@ -1,38 +1,21 @@
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import childProcess from 'node:child_process';
-import fs from 'node:fs';
-import os from 'node:os';
-
-// Must import after stubs are set up — but ESM imports are hoisted.
-// We use dynamic import inside tests to work around this.
-// However, since the module reads platform() at call time (not import time),
-// we can stub os.platform before calling the functions.
 
 import { preflightCheck } from './preflight.js';
+import type { DriverResolution, ResolveOptions } from './driver-provision.js';
 
 describe('preflightCheck', () => {
-  let execFileStub: sinon.SinonStub;
-  let existsStub: sinon.SinonStub;
-  let rmStub: sinon.SinonStub;
-  let platformStub: sinon.SinonStub;
-  let homedirStub: sinon.SinonStub;
   let consoleErrorStub: sinon.SinonStub;
   const originalEnv = { ...process.env };
 
+  /** Build a resolver stub that resolves to a driver path. */
+  function resolvingResolver(over: Partial<DriverResolution> = {}): sinon.SinonStub {
+    return sinon.stub().resolves({ driverPath: '/cache/chromedriver', fromCache: false, ...over });
+  }
+
   beforeEach(() => {
-    execFileStub = sinon.stub(childProcess, 'execFileSync');
-    existsStub = sinon.stub(fs, 'existsSync');
-    rmStub = sinon.stub(fs, 'rmSync');
-    platformStub = sinon.stub(os, 'platform').returns('linux');
-    homedirStub = sinon.stub(os, 'homedir').returns('/home/testuser');
     consoleErrorStub = sinon.stub(console, 'error');
-
-    // Default: binary exists
-    existsStub.returns(true);
-
-    // Clean env
     delete process.env.SELENIUM_AI_AGENT_SKIP_PREFLIGHT;
     delete process.env.SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS;
   });
@@ -42,175 +25,89 @@ describe('preflightCheck', () => {
     process.env = { ...originalEnv };
   });
 
-  it('should return ok when Selenium Manager succeeds', async () => {
-    execFileStub.returns('{"result": {}}');
+  it('should return ok when the driver resolves', async () => {
+    const resolver = resolvingResolver();
 
-    const result = await preflightCheck();
+    const result = await preflightCheck(resolver);
 
     expect(result.ok).to.equal(true);
-    expect(execFileStub.calledOnce).to.equal(true);
+    expect(resolver.calledOnce).to.equal(true);
+  });
+
+  it('should report whether the driver came from cache', async () => {
+    const result = await preflightCheck(resolvingResolver({ fromCache: true, driverPath: '/c/d' }));
+
+    expect(result.ok).to.equal(true);
+    expect(result.fromCache).to.equal(true);
+    expect(result.driverPath).to.equal('/c/d');
   });
 
   it('should skip when SELENIUM_AI_AGENT_SKIP_PREFLIGHT=1', async () => {
     process.env.SELENIUM_AI_AGENT_SKIP_PREFLIGHT = '1';
+    const resolver = resolvingResolver();
 
-    const result = await preflightCheck();
+    const result = await preflightCheck(resolver);
 
     expect(result.ok).to.equal(true);
-    expect(execFileStub.called).to.equal(false);
+    expect(resolver.called).to.equal(false);
   });
 
   it('should not skip when SELENIUM_AI_AGENT_SKIP_PREFLIGHT is not 1', async () => {
     process.env.SELENIUM_AI_AGENT_SKIP_PREFLIGHT = '0';
-    execFileStub.returns('{}');
+    const resolver = resolvingResolver();
 
-    const result = await preflightCheck();
+    const result = await preflightCheck(resolver);
 
     expect(result.ok).to.equal(true);
-    expect(execFileStub.called).to.equal(true);
-  });
-
-  it('should fail when binary is not found', async () => {
-    existsStub.returns(false);
-
-    const result = await preflightCheck();
-
-    expect(result.ok).to.equal(false);
-    expect(result.category).to.equal('UNKNOWN');
-    expect(result.stderr).to.include('not found');
+    expect(resolver.called).to.equal(true);
   });
 
   it('should classify NETWORK_UNREACHABLE errors', async () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'No route to host (os error 65)';
-    execFileStub.throws(error);
+    const resolver = sinon.stub().rejects(new Error('No route to host (os error 65)'));
 
-    const result = await preflightCheck();
+    const result = await preflightCheck(resolver);
 
     expect(result.ok).to.equal(false);
     expect(result.category).to.equal('NETWORK_UNREACHABLE');
   });
 
   it('should classify DOWNLOAD_FAILED errors', async () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'error sending request for url https://storage.googleapis.com/...';
-    execFileStub.throws(error);
+    const resolver = sinon.stub().rejects(
+      new Error('error sending request for url https://storage.googleapis.com/...'),
+    );
 
-    const result = await preflightCheck();
+    const result = await preflightCheck(resolver);
 
     expect(result.ok).to.equal(false);
     expect(result.category).to.equal('DOWNLOAD_FAILED');
   });
 
-  it('should auto-recover by clearing cache and retrying', async () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'No route to host';
+  it('should include a recommendation in the failure result', async () => {
+    const resolver = sinon.stub().rejects(new Error('No route to host'));
 
-    // First call fails, second succeeds
-    execFileStub.onFirstCall().throws(error);
-    execFileStub.onSecondCall().returns('{}');
-
-    const result = await preflightCheck();
-
-    expect(result.ok).to.equal(true);
-    expect(execFileStub.calledTwice).to.equal(true);
-    expect(rmStub.called).to.equal(true);
-  });
-
-  it('should fail after retry if both attempts fail', async () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'No route to host';
-    execFileStub.throws(error);
-
-    const result = await preflightCheck();
-
-    expect(result.ok).to.equal(false);
-    expect(execFileStub.calledTwice).to.equal(true);
-  });
-
-  it('should handle cache clear failure gracefully', async () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'No route to host';
-    execFileStub.throws(error);
-    rmStub.throws(new Error('EPERM'));
-
-    const result = await preflightCheck();
-
-    expect(result.ok).to.equal(false);
-    // Should not throw — cache clear is best-effort
-  });
-
-  it('should use custom timeout from env var', async () => {
-    process.env.SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS = '5000';
-    execFileStub.returns('{}');
-
-    await preflightCheck();
-
-    const callArgs = execFileStub.firstCall.args;
-    expect(callArgs[2]).to.have.property('timeout', 5000);
-  });
-
-  it('should use default timeout for invalid env var', async () => {
-    process.env.SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS = 'not-a-number';
-    execFileStub.returns('{}');
-
-    await preflightCheck();
-
-    const callArgs = execFileStub.firstCall.args;
-    expect(callArgs[2]).to.have.property('timeout', 30000);
-  });
-
-  it('should use default timeout for negative env var', async () => {
-    process.env.SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS = '-1';
-    execFileStub.returns('{}');
-
-    await preflightCheck();
-
-    const callArgs = execFileStub.firstCall.args;
-    expect(callArgs[2]).to.have.property('timeout', 30000);
-  });
-
-  it('should resolve linux binary path', async () => {
-    platformStub.returns('linux');
-    execFileStub.returns('{}');
-
-    await preflightCheck();
-
-    const binaryPath = execFileStub.firstCall.args[0] as string;
-    // Normalize separators for cross-platform assertion
-    const normalized = binaryPath.replace(/\\/g, '/');
-    expect(normalized).to.include('bin/linux/selenium-manager');
-  });
-
-  it('should resolve windows binary path', async () => {
-    platformStub.returns('win32');
-    execFileStub.returns('{}');
-
-    await preflightCheck();
-
-    const binaryPath = execFileStub.firstCall.args[0] as string;
-    expect(binaryPath).to.include('selenium-manager.exe');
-  });
-
-  it('should resolve macOS binary path', async () => {
-    platformStub.returns('darwin');
-    execFileStub.returns('{}');
-
-    await preflightCheck();
-
-    const binaryPath = execFileStub.firstCall.args[0] as string;
-    const normalized = binaryPath.replace(/\\/g, '/');
-    expect(normalized).to.include('bin/macos/selenium-manager');
-  });
-
-  it('should include recommendation in failure result', async () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'No route to host';
-    execFileStub.throws(error);
-
-    const result = await preflightCheck();
+    const result = await preflightCheck(resolver);
 
     expect(result.recommendation).to.be.a('string');
     expect(result.recommendation!.length).to.be.greaterThan(0);
+  });
+
+  it('should pass the configured timeout to the resolver', async () => {
+    process.env.SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS = '5000';
+    const resolver = resolvingResolver();
+
+    await preflightCheck(resolver);
+
+    const opts = resolver.firstCall.args[0] as ResolveOptions;
+    expect(opts.timeoutMs).to.equal(5000);
+  });
+
+  it('should use the default timeout for an invalid env var', async () => {
+    process.env.SELENIUM_AI_AGENT_PREFLIGHT_TIMEOUT_MS = 'not-a-number';
+    const resolver = resolvingResolver();
+
+    await preflightCheck(resolver);
+
+    const opts = resolver.firstCall.args[0] as ResolveOptions;
+    expect(opts.timeoutMs).to.equal(30000);
   });
 });

--- a/selenium-mcp-server/src/preflight.ts
+++ b/selenium-mcp-server/src/preflight.ts
@@ -1,7 +1,4 @@
-import { execFileSync } from 'node:child_process';
-import { existsSync, rmSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { homedir, platform } from 'node:os';
+import { resolveDriver, type ResolveOptions, type DriverResolution } from './driver-provision.js';
 import { classifyDriverError, buildDriverErrorMessage, type ErrorCategory } from './driver-errors.js';
 
 export interface PreflightResult {
@@ -9,77 +6,12 @@ export interface PreflightResult {
   category?: ErrorCategory;
   stderr?: string;
   recommendation?: string;
+  driverPath?: string;
+  fromCache?: boolean;
 }
 
-function getSeleniumManagerPath(): string {
-  const plat = platform();
-  let relative: string;
-  switch (plat) {
-    case 'darwin':
-      relative = 'bin/macos/selenium-manager';
-      break;
-    case 'win32':
-      relative = 'bin/windows/selenium-manager.exe';
-      break;
-    default:
-      relative = 'bin/linux/selenium-manager';
-      break;
-  }
-
-  // Resolve from the selenium-webdriver package
-  try {
-    const seleniumDir = join(
-      resolve('node_modules', 'selenium-webdriver'),
-      relative,
-    );
-    if (existsSync(seleniumDir)) return seleniumDir;
-  } catch { /* fall through */ }
-
-  // Fallback: try relative to cwd
-  const fallback = join(process.cwd(), 'node_modules', 'selenium-webdriver', relative);
-  return fallback;
-}
-
-function getSeleniumCacheDir(): string {
-  const plat = platform();
-  if (plat === 'win32') {
-    return join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'selenium');
-  }
-  return join(homedir(), '.cache', 'selenium');
-}
-
-function clearSeleniumCache(): boolean {
-  const cacheDir = getSeleniumCacheDir();
-  try {
-    if (existsSync(cacheDir)) {
-      rmSync(cacheDir, { recursive: true, force: true });
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function runSeleniumManager(binaryPath: string, timeoutMs: number): PreflightResult {
-  try {
-    execFileSync(binaryPath, ['--browser', 'chrome', '--output', 'json'], {
-      timeout: timeoutMs,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { ok: true };
-  } catch (err: unknown) {
-    const stderr = (err as { stderr?: string }).stderr || '';
-    const message = err instanceof Error ? err.message : String(err);
-    const errorText = stderr || message;
-
-    const category = classifyDriverError(errorText);
-    const syntheticErr = new Error(errorText);
-    const recommendation = buildDriverErrorMessage(category, syntheticErr);
-
-    return { ok: false, category, stderr: errorText, recommendation };
-  }
-}
+/** Signature of the driver resolver, injectable for testing. */
+export type DriverResolver = (opts: ResolveOptions) => Promise<DriverResolution>;
 
 function parseTimeout(): number {
   const DEFAULT_TIMEOUT = 30_000;
@@ -98,44 +30,32 @@ function parseTimeout(): number {
   return parsed;
 }
 
-export async function preflightCheck(): Promise<PreflightResult> {
+/**
+ * Validate driver acquisition at server start-up. Delegates to resolveDriver,
+ * which handles proxy injection, cached-version reuse, corrupt-cache repair and
+ * backoff. Failures are classified into an actionable recommendation rather
+ * than surfaced as the opaque "Unable to obtain browser driver".
+ */
+export async function preflightCheck(resolver: DriverResolver = resolveDriver): Promise<PreflightResult> {
   // FR-5.1: Skip via env var
   if (process.env.SELENIUM_AI_AGENT_SKIP_PREFLIGHT === '1') {
     console.error('[debug] Pre-flight check skipped (SELENIUM_AI_AGENT_SKIP_PREFLIGHT=1)');
     return { ok: true };
   }
 
-  const binaryPath = getSeleniumManagerPath();
   const timeoutMs = parseTimeout();
 
-  if (!existsSync(binaryPath)) {
-    return {
-      ok: false,
-      category: 'UNKNOWN',
-      stderr: `Selenium Manager binary not found at: ${binaryPath}`,
-      recommendation: 'Ensure selenium-webdriver is installed: npm install selenium-webdriver',
-    };
+  try {
+    const { driverPath, fromCache } = await resolver({ timeoutMs });
+    console.error(
+      `[debug] Pre-flight check passed (${fromCache ? 'cached' : 'resolved'} driver: ${driverPath})`,
+    );
+    return { ok: true, driverPath, fromCache };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    const category = classifyDriverError(error.message);
+    const recommendation = buildDriverErrorMessage(category, error);
+    console.error(`[error] Pre-flight check failed: ${category}`);
+    return { ok: false, category, stderr: error.message, recommendation };
   }
-
-  // First attempt
-  let result = runSeleniumManager(binaryPath, timeoutMs);
-
-  if (result.ok) {
-    console.error('[debug] Pre-flight check passed');
-    return result;
-  }
-
-  // Auto-recovery: clear cache and retry once
-  console.error('[debug] Pre-flight failed, clearing Selenium cache and retrying...');
-  clearSeleniumCache();
-
-  result = runSeleniumManager(binaryPath, timeoutMs);
-
-  if (result.ok) {
-    console.error('[debug] Pre-flight passed after cache clear');
-    return result;
-  }
-
-  console.error(`[error] Pre-flight check failed: ${result.category}`);
-  return result;
 }

--- a/selenium-mcp-server/src/proxy-config.test.ts
+++ b/selenium-mcp-server/src/proxy-config.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'node:fs';
+import os from 'node:os';
+
+import { loadProxyConfig, buildSubprocessEnv, getConfigPath } from './proxy-config.js';
+
+describe('proxy-config', () => {
+  let existsStub: sinon.SinonStub;
+  let readStub: sinon.SinonStub;
+  let homedirStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    existsStub = sinon.stub(fs, 'existsSync');
+    readStub = sinon.stub(fs, 'readFileSync');
+    homedirStub = sinon.stub(os, 'homedir').returns('/home/testuser');
+    consoleErrorStub = sinon.stub(console, 'error');
+
+    // Default: no config file present
+    existsStub.returns(false);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getConfigPath', () => {
+    it('should default to ~/.selenium-ai-agent/config.json', () => {
+      const path = getConfigPath({});
+      const normalized = path.replace(/\\/g, '/');
+      expect(normalized).to.equal('/home/testuser/.selenium-ai-agent/config.json');
+    });
+
+    it('should honour the SELENIUM_AI_AGENT_CONFIG override', () => {
+      const path = getConfigPath({ SELENIUM_AI_AGENT_CONFIG: '/etc/selenium/cfg.json' });
+      expect(path).to.equal('/etc/selenium/cfg.json');
+    });
+  });
+
+  describe('loadProxyConfig', () => {
+    it('should return an empty config when no file and no env vars exist', () => {
+      const config = loadProxyConfig({});
+      expect(config.proxy).to.equal(undefined);
+      expect(config.noProxy).to.equal(undefined);
+    });
+
+    it('should read the proxy from the config file', () => {
+      existsStub.returns(true);
+      readStub.returns(JSON.stringify({ proxy: 'http://file-proxy:8080' }));
+
+      const config = loadProxyConfig({});
+      expect(config.proxy).to.equal('http://file-proxy:8080');
+    });
+
+    it('should let HTTPS_PROXY env var override the config file', () => {
+      existsStub.returns(true);
+      readStub.returns(JSON.stringify({ proxy: 'http://file-proxy:8080' }));
+
+      const config = loadProxyConfig({ HTTPS_PROXY: 'http://env-proxy:3128' });
+      expect(config.proxy).to.equal('http://env-proxy:3128');
+    });
+
+    it('should pick up the lower-case https_proxy env var', () => {
+      const config = loadProxyConfig({ https_proxy: 'http://lower-proxy:3128' });
+      expect(config.proxy).to.equal('http://lower-proxy:3128');
+    });
+
+    it('should fall back to HTTP_PROXY when HTTPS_PROXY is absent', () => {
+      const config = loadProxyConfig({ HTTP_PROXY: 'http://http-only:3128' });
+      expect(config.proxy).to.equal('http://http-only:3128');
+    });
+
+    it('should read NO_PROXY from the environment', () => {
+      const config = loadProxyConfig({ NO_PROXY: 'localhost,127.0.0.1' });
+      expect(config.noProxy).to.equal('localhost,127.0.0.1');
+    });
+
+    it('should ignore a malformed JSON config file without throwing', () => {
+      existsStub.returns(true);
+      readStub.returns('{ this is not json');
+
+      const config = loadProxyConfig({});
+      expect(config.proxy).to.equal(undefined);
+      expect(consoleErrorStub.called).to.equal(true);
+    });
+
+    it('should ignore a non-string proxy field', () => {
+      existsStub.returns(true);
+      readStub.returns(JSON.stringify({ proxy: 1234 }));
+
+      const config = loadProxyConfig({});
+      expect(config.proxy).to.equal(undefined);
+    });
+
+    it('should treat a whitespace-only proxy value as unset', () => {
+      existsStub.returns(true);
+      readStub.returns(JSON.stringify({ proxy: '   ' }));
+
+      const config = loadProxyConfig({});
+      expect(config.proxy).to.equal(undefined);
+    });
+  });
+
+  describe('buildSubprocessEnv', () => {
+    it('should inject the proxy into both HTTP and HTTPS env vars', () => {
+      const env = buildSubprocessEnv({}, { proxy: 'http://corp:8080' });
+      expect(env.HTTPS_PROXY).to.equal('http://corp:8080');
+      expect(env.HTTP_PROXY).to.equal('http://corp:8080');
+      expect(env.https_proxy).to.equal('http://corp:8080');
+      expect(env.http_proxy).to.equal('http://corp:8080');
+    });
+
+    it('should inject NO_PROXY when provided', () => {
+      const env = buildSubprocessEnv({}, { noProxy: 'localhost' });
+      expect(env.NO_PROXY).to.equal('localhost');
+      expect(env.no_proxy).to.equal('localhost');
+    });
+
+    it('should preserve the base environment', () => {
+      const env = buildSubprocessEnv({ PATH: '/usr/bin', FOO: 'bar' }, { proxy: 'http://corp:8080' });
+      expect(env.PATH).to.equal('/usr/bin');
+      expect(env.FOO).to.equal('bar');
+    });
+
+    it('should not set proxy vars when the config has no proxy', () => {
+      const env = buildSubprocessEnv({ PATH: '/usr/bin' }, {});
+      expect(env.HTTPS_PROXY).to.equal(undefined);
+      expect(env.HTTP_PROXY).to.equal(undefined);
+    });
+  });
+});

--- a/selenium-mcp-server/src/proxy-config.ts
+++ b/selenium-mcp-server/src/proxy-config.ts
@@ -1,0 +1,127 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Proxy settings resolved for the driver-download subprocess.
+ *
+ * Both fields are optional: an absent field means "no explicit setting,
+ * let the subprocess fall back to its own defaults".
+ */
+export interface ProxyConfig {
+  /** Proxy URL applied to both HTTP and HTTPS traffic (e.g. http://proxy.corp:8080). */
+  readonly proxy?: string;
+  /** Comma-separated list of hosts that bypass the proxy. */
+  readonly noProxy?: string;
+}
+
+/** Shape of the on-disk config file before validation. */
+interface RawConfig {
+  readonly proxy?: unknown;
+  readonly noProxy?: unknown;
+}
+
+/**
+ * Resolve the config-file path: the SELENIUM_AI_AGENT_CONFIG override if set,
+ * otherwise ~/.selenium-ai-agent/config.json.
+ *
+ * A file in the home directory (not the project) is the only reliable source
+ * for a GUI-launched MCP server, which does not inherit the user's shell env.
+ */
+export function getConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.SELENIUM_AI_AGENT_CONFIG?.trim();
+  if (override) return override;
+  return join(homedir(), '.selenium-ai-agent', 'config.json');
+}
+
+/** Return the first non-empty env var among the given names (case variants). */
+function envValue(env: NodeJS.ProcessEnv, names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const value = env[name];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Validate one config field as a non-empty string, warning (not throwing) on bad input. */
+function readStringField(value: unknown, field: string, path: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    console.error(`[warn] proxy config "${field}" in ${path} must be a string; ignoring`);
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Read and validate the config file. Malformed input is ignored (warns), never thrown. */
+function readConfigFile(path: string): ProxyConfig {
+  if (!existsSync(path)) return {};
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (err) {
+    console.error(`[warn] could not read proxy config at ${path}: ${(err as Error).message}`);
+    return {};
+  }
+
+  let parsed: RawConfig;
+  try {
+    parsed = JSON.parse(raw) as RawConfig;
+  } catch (err) {
+    console.error(`[warn] proxy config at ${path} is not valid JSON; ignoring: ${(err as Error).message}`);
+    return {};
+  }
+
+  return {
+    proxy: readStringField(parsed.proxy, 'proxy', path),
+    noProxy: readStringField(parsed.noProxy, 'noProxy', path),
+  };
+}
+
+/**
+ * Load the effective proxy configuration by merging the config file with the
+ * environment. Standard proxy env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY,
+ * upper- and lower-case) take precedence over the file so CI and containers can
+ * override without editing the file.
+ */
+export function loadProxyConfig(env: NodeJS.ProcessEnv = process.env): ProxyConfig {
+  const fromFile = readConfigFile(getConfigPath(env));
+
+  const envProxy = envValue(env, ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy']);
+  const envNoProxy = envValue(env, ['NO_PROXY', 'no_proxy']);
+
+  return {
+    proxy: envProxy ?? fromFile.proxy,
+    noProxy: envNoProxy ?? fromFile.noProxy,
+  };
+}
+
+/**
+ * Produce an environment for a child process that resolves/downloads the driver,
+ * with the proxy settings injected explicitly. This is the key fix for
+ * GUI-launched servers: the subprocess no longer relies on inherited shell env.
+ */
+export function buildSubprocessEnv(
+  base: NodeJS.ProcessEnv,
+  config: ProxyConfig,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...base };
+
+  if (config.proxy) {
+    env.HTTPS_PROXY = config.proxy;
+    env.HTTP_PROXY = config.proxy;
+    env.https_proxy = config.proxy;
+    env.http_proxy = config.proxy;
+  }
+
+  if (config.noProxy) {
+    env.NO_PROXY = config.noProxy;
+    env.no_proxy = config.noProxy;
+  }
+
+  return env;
+}


### PR DESCRIPTION
## Why

First-time users on locked-down machines failed at startup because driver resolution happened implicitly inside Selenium's `.build()`:

1. A GUI-launched MCP server does **not** inherit the shell proxy, so the chromedriver download was blocked.
2. An interrupted download left an unextracted `.zip` / non-executable file in the cache that got spawned as an executable → `EACCES` / "Exec format error".

## What changed

Provision the driver explicitly **before** launching the browser:

- **Version-aware reuse** — detect the installed Chrome version, reuse a matching cached driver, and only resolve/download when the major no longer matches. The verified path is handed to the `Service` so `.build()` never auto-downloads. *Nothing is pinned — it tracks Chrome updates automatically.*
- **Corrupt-cache repair** — reject an unextracted `.zip` / non-executable driver, remove just that cache entry, and retry with exponential backoff. Never spawns a `.zip`.
- **Proxy robustness** — read the proxy from one config file (`~/.selenium-ai-agent/config.json`) **and** the standard `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` vars, injected explicitly into the download subprocess.
- **`doctor` command** — `npx selenium-ai-agent doctor` checks Chrome + version, a ready executable driver, endpoint reachability (through the proxy) and the cache location, with a concrete fix per failed check.
- **Preflight** now delegates to the same provisioning (proxy + backoff + targeted repair) and **fixes a Windows bug**: Selenium's cache is `~/.cache/selenium` on every platform, not `%LOCALAPPDATA%`.

## Tests & CI

- 94 unit tests (proxy precedence, version-match, corrupt-cache detection, doctor checks, preflight). All green on Windows + Linux locally.
- New **gating** `driver-provisioning` CI job: runs the unit suite **and a real chromedriver download** on `ubuntu`/`macos`/`windows` (unlike the existing lenient `test` job).

## Notes

- Exceeds the 400-line PR guideline (largely tests + README); kept as one cohesive change by request.
- Escape hatches: `SELENIUM_AI_AGENT_SKIP_PROVISION=1`, `SE_CACHE_PATH`, `SELENIUM_AI_AGENT_CONFIG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)