### PR TITLE
fix: resolve selenium-manager binary from package install, not cwd

### DIFF
--- a/selenium-mcp-server/CHANGELOG.md
+++ b/selenium-mcp-server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.3.1] - 2026-06-19
+
+### Fixes
+
+- **Selenium Manager binary not found under npx** — driver provisioning failed on first use with `Selenium Manager binary not found at: /node_modules/selenium-webdriver/bin/.../selenium-manager` (note the leading slash). The bundled binary was resolved relative to `process.cwd()` instead of the real install location, so it was never found under `npx` (where `selenium-webdriver` lives in the npx cache). It is now resolved via Node's module resolution from the installed `selenium-webdriver` package, working under npx, global and local installs alike.
+  - The platform sub-path is chosen from `process.platform` (`darwin` → `bin/macos`, `linux` → `bin/linux`, `win32` → `bin/windows/...exe`).
+  - Resolution now fails with a clear, actionable error (the attempted path plus a reinstall hint) when the binary is genuinely missing or not executable.
+  - The `doctor` command reports the resolved Selenium Manager path and whether it exists and is executable, and the diagnostic command in error messages points at the resolved path instead of a hardcoded `./node_modules/...`.
+
 ## [3.3.0] - 2026-06-19
 
 ### New Features

--- a/selenium-mcp-server/README.md
+++ b/selenium-mcp-server/README.md
@@ -47,10 +47,16 @@ node dist/bin/cli.js doctor
 
 It checks, and prints a concrete fix for anything that fails:
 
+- the bundled Selenium Manager binary resolves and is executable,
 - Chrome is installed and which version,
 - an executable, matching `chromedriver` is cached and ready,
 - the download endpoint is reachable (through your proxy, if configured),
 - where the driver cache lives.
+
+> **`Selenium Manager binary not found at: /node_modules/...`?** Fixed in 3.3.1 —
+> upgrade with `npm install -g selenium-ai-agent@latest` (or clear the npx cache).
+> The binary is now resolved from the installed `selenium-webdriver` package
+> rather than the working directory, so it works under npx.
 
 ### Corporate proxy
 

--- a/selenium-mcp-server/src/doctor.test.ts
+++ b/selenium-mcp-server/src/doctor.test.ts
@@ -7,6 +7,7 @@ describe('doctor', () => {
   const happy: Partial<DoctorDeps> = {
     detectChrome: () => ({ version: '149.0.7827.155', major: 149 }),
     findCached: () => '/cache/chromedriver/win64/149.0.7827.155/chromedriver.exe',
+    inspectManager: () => ({ path: '/sw/bin/macos/selenium-manager', exists: true, executable: true }),
     probe: async () => true,
     proxy: undefined,
     cacheDir: '/home/u/.cache/selenium',
@@ -16,6 +17,35 @@ describe('doctor', () => {
     const report = await runDoctor(happy);
     expect(report.ok).to.equal(true);
     expect(report.checks.find((c) => c.name === 'Chrome installed')!.ok).to.equal(true);
+  });
+
+  it('should show the resolved Selenium Manager path when it is executable', async () => {
+    const report = await runDoctor(happy);
+    const mgr = report.checks.find((c) => c.name === 'Selenium Manager binary')!;
+    expect(mgr.ok).to.equal(true);
+    expect(mgr.detail).to.include('/sw/bin/macos/selenium-manager');
+  });
+
+  it('should fail the manager check with the attempted path when the binary is missing', async () => {
+    const report = await runDoctor({
+      ...happy,
+      inspectManager: () => ({ path: '/sw/bin/macos/selenium-manager', exists: false, executable: false }),
+    });
+    const mgr = report.checks.find((c) => c.name === 'Selenium Manager binary')!;
+    expect(mgr.ok).to.equal(false);
+    expect(mgr.detail).to.include('not found: /sw/bin/macos/selenium-manager');
+    expect(mgr.fix).to.be.a('string');
+    expect(report.ok).to.equal(false);
+  });
+
+  it('should fail the manager check when selenium-webdriver cannot be resolved', async () => {
+    const report = await runDoctor({
+      ...happy,
+      inspectManager: () => ({ path: null, exists: false, executable: false }),
+    });
+    const mgr = report.checks.find((c) => c.name === 'Selenium Manager binary')!;
+    expect(mgr.ok).to.equal(false);
+    expect(mgr.detail).to.include('could not be resolved');
   });
 
   it('should fail the Chrome check with a fix when Chrome is absent', async () => {

--- a/selenium-mcp-server/src/doctor.ts
+++ b/selenium-mcp-server/src/doctor.ts
@@ -4,9 +4,17 @@ import {
   detectChromeVersion,
   findCachedDriver,
   getSeleniumCacheDir,
+  inspectSeleniumManager,
   type ChromeInfo,
 } from './driver-provision.js';
 import { loadProxyConfig } from './proxy-config.js';
+
+/** Outcome of inspecting the bundled Selenium Manager binary. */
+export interface ManagerInfo {
+  readonly path: string | null;
+  readonly exists: boolean;
+  readonly executable: boolean;
+}
 
 /** Result of a single doctor check. */
 export interface DoctorCheck {
@@ -26,6 +34,7 @@ export interface DoctorReport {
 export interface DoctorDeps {
   detectChrome: () => ChromeInfo | null;
   findCached: (major: number) => string | null;
+  inspectManager: () => ManagerInfo;
   probe: (host: string, port: number, timeoutMs: number) => Promise<boolean>;
   proxy?: string;
   cacheDir: string;
@@ -143,6 +152,24 @@ async function checkEndpoint(
   };
 }
 
+function checkManager(info: ManagerInfo): DoctorCheck {
+  if (info.exists && info.executable) {
+    return { name: 'Selenium Manager binary', ok: true, detail: `executable: ${info.path}` };
+  }
+  const detail = !info.path
+    ? 'selenium-webdriver could not be resolved'
+    : info.exists
+      ? `present but not executable: ${info.path}`
+      : `not found: ${info.path}`;
+  return {
+    name: 'Selenium Manager binary',
+    ok: false,
+    detail,
+    fix: 'selenium-webdriver is missing or incompletely installed — reinstall it '
+      + '(npm install selenium-webdriver). Under npx, clear the npx cache and retry.',
+  };
+}
+
 function checkCache(cacheDir: string): DoctorCheck {
   const present = existsSync(cacheDir);
   return {
@@ -156,6 +183,7 @@ function defaultDeps(): DoctorDeps {
   return {
     detectChrome: detectChromeVersion,
     findCached: (major) => findCachedDriver(major),
+    inspectManager: inspectSeleniumManager,
     probe: tcpProbe,
     proxy: loadProxyConfig().proxy,
     cacheDir: getSeleniumCacheDir(),
@@ -171,6 +199,7 @@ export async function runDoctor(deps: Partial<DoctorDeps> = {}): Promise<DoctorR
 
   const chrome = d.detectChrome();
   const checks: DoctorCheck[] = [
+    checkManager(d.inspectManager()),
     checkChrome(chrome),
     checkDriver(chrome, d.findCached),
     await checkEndpoint(d.proxy, d.probe),

--- a/selenium-mcp-server/src/driver-errors.test.ts
+++ b/selenium-mcp-server/src/driver-errors.test.ts
@@ -1,7 +1,5 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
-import os from 'node:os';
 import {
   classifyDriverError,
   getDiagnosticCommand,
@@ -45,29 +43,18 @@ describe('classifyDriverError', () => {
 });
 
 describe('getDiagnosticCommand', () => {
-  afterEach(() => {
-    sinon.restore();
+  it('should quote an injected manager path and append the debug flags', () => {
+    const cmd = getDiagnosticCommand('/opt/sw/bin/macos/selenium-manager');
+    expect(cmd).to.equal('"/opt/sw/bin/macos/selenium-manager" --browser chrome --debug');
   });
 
-  it('should return macOS path on darwin', () => {
-    sinon.stub(os, 'platform').returns('darwin');
+  it('should reference the actually-resolved selenium-manager path by default', () => {
     const cmd = getDiagnosticCommand();
-    expect(cmd).to.include('bin/macos/selenium-manager');
+    expect(cmd).to.include('selenium-manager');
+    expect(cmd).to.include('selenium-webdriver');
     expect(cmd).to.include('--browser chrome --debug');
-  });
-
-  it('should return Windows path on win32', () => {
-    sinon.stub(os, 'platform').returns('win32');
-    const cmd = getDiagnosticCommand();
-    expect(cmd).to.include('bin\\windows\\selenium-manager.exe');
-    expect(cmd).to.include('--browser chrome --debug');
-  });
-
-  it('should return Linux path on linux', () => {
-    sinon.stub(os, 'platform').returns('linux');
-    const cmd = getDiagnosticCommand();
-    expect(cmd).to.include('bin/linux/selenium-manager');
-    expect(cmd).to.include('--browser chrome --debug');
+    // Never the old root-anchored guess.
+    expect(cmd.startsWith('"/node_modules/')).to.equal(false);
   });
 });
 

--- a/selenium-mcp-server/src/driver-errors.ts
+++ b/selenium-mcp-server/src/driver-errors.ts
@@ -1,4 +1,5 @@
-import { platform } from 'node:os';
+import { join } from 'node:path';
+import { inspectSeleniumManager, seleniumManagerRelativePath } from './driver-provision.js';
 
 export type ErrorCategory =
   | 'NETWORK_UNREACHABLE'
@@ -56,16 +57,13 @@ export function classifyDriverError(errorText: string): ErrorCategory {
   return 'UNKNOWN';
 }
 
-export function getDiagnosticCommand(): string {
-  const plat = platform();
-  switch (plat) {
-    case 'darwin':
-      return './node_modules/selenium-webdriver/bin/macos/selenium-manager --browser chrome --debug';
-    case 'win32':
-      return '.\\node_modules\\selenium-webdriver\\bin\\windows\\selenium-manager.exe --browser chrome --debug';
-    default:
-      return './node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome --debug';
-  }
+export function getDiagnosticCommand(managerPath?: string): string {
+  // Point at the actually-resolved Selenium Manager (works under npx/global/
+  // local). Fall back to a relative best-guess only if it cannot be resolved.
+  const resolved = managerPath
+    ?? inspectSeleniumManager().path
+    ?? join('node_modules', 'selenium-webdriver', seleniumManagerRelativePath());
+  return `"${resolved}" --browser chrome --debug`;
 }
 
 const REMEDIATION: Record<ErrorCategory, (original: string) => string> = {

--- a/selenium-mcp-server/src/driver-provision.test.ts
+++ b/selenium-mcp-server/src/driver-provision.test.ts
@@ -14,6 +14,10 @@ import {
   getSeleniumCacheDir,
   detectChromeVersion,
   resolveDriver,
+  seleniumManagerRelativePath,
+  getSeleniumManagerPath,
+  getSeleniumWebdriverDir,
+  resolveSeleniumManager,
   type ResolveDeps,
   type ChromeInfo,
 } from './driver-provision.js';
@@ -144,6 +148,64 @@ describe('driver-provision', () => {
       execStub.throws(new Error('ENOENT'));
 
       expect(detectChromeVersion()).to.equal(null);
+    });
+  });
+
+  describe('seleniumManagerRelativePath', () => {
+    it('should use the macos binary on darwin', () => {
+      expect(seleniumManagerRelativePath('darwin')).to.equal('bin/macos/selenium-manager');
+    });
+
+    it('should use the windows .exe binary on win32', () => {
+      expect(seleniumManagerRelativePath('win32')).to.equal('bin/windows/selenium-manager.exe');
+    });
+
+    it('should use the linux binary on linux', () => {
+      expect(seleniumManagerRelativePath('linux')).to.equal('bin/linux/selenium-manager');
+    });
+  });
+
+  describe('getSeleniumManagerPath', () => {
+    it('should join the injected base dir with the macOS sub-path', () => {
+      const p = getSeleniumManagerPath('darwin', '/fake/selenium-webdriver').replace(/\\/g, '/');
+      expect(p).to.equal('/fake/selenium-webdriver/bin/macos/selenium-manager');
+    });
+
+    it('should append .exe under the windows sub-path', () => {
+      const p = getSeleniumManagerPath('win32', '/fake/selenium-webdriver').replace(/\\/g, '/');
+      expect(p).to.equal('/fake/selenium-webdriver/bin/windows/selenium-manager.exe');
+    });
+
+    it('should join the injected base dir with the linux sub-path', () => {
+      const p = getSeleniumManagerPath('linux', '/fake/selenium-webdriver').replace(/\\/g, '/');
+      expect(p).to.equal('/fake/selenium-webdriver/bin/linux/selenium-manager');
+    });
+
+    it('should default the base to the real selenium-webdriver install (not cwd)', () => {
+      // The real package is resolvable in this repo; the path must live under it,
+      // never starting from the filesystem root as the old cwd-based lookup did.
+      const dir = getSeleniumWebdriverDir().replace(/\\/g, '/');
+      expect(dir).to.include('selenium-webdriver');
+      const p = getSeleniumManagerPath().replace(/\\/g, '/');
+      expect(p.startsWith(dir)).to.equal(true);
+      expect(p.startsWith('/node_modules/')).to.equal(false);
+    });
+  });
+
+  describe('resolveSeleniumManager', () => {
+    it('should throw with the attempted path and a hint when the binary is missing', () => {
+      sinon.stub(fs, 'existsSync').returns(false);
+
+      let thrown: Error | null = null;
+      try {
+        resolveSeleniumManager();
+      } catch (err) {
+        thrown = err as Error;
+      }
+
+      expect(thrown).to.not.equal(null);
+      expect(thrown!.message).to.include('Selenium Manager binary not found at:');
+      expect(thrown!.message.toLowerCase()).to.include('reinstall');
     });
   });
 

--- a/selenium-mcp-server/src/driver-provision.ts
+++ b/selenium-mcp-server/src/driver-provision.ts
@@ -1,8 +1,14 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, statSync, readdirSync, rmSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir, platform } from 'node:os';
+import { createRequire } from 'node:module';
 import { loadProxyConfig, buildSubprocessEnv } from './proxy-config.js';
+
+// Resolve dependencies relative to THIS module's real location, so the bundled
+// selenium-webdriver is found regardless of cwd (the previous cwd-based lookup
+// broke under npx, where selenium-webdriver lives in the npx cache).
+const requireFromHere = createRequire(import.meta.url);
 
 /** Installed Chrome browser, as far as it could be detected. */
 export interface ChromeInfo {
@@ -158,29 +164,95 @@ export function removeCacheEntry(driverPath: string): void {
 // Selenium Manager invocation
 // ---------------------------------------------------------------------------
 
-/** Locate the bundled Selenium Manager binary inside selenium-webdriver. */
-export function getSeleniumManagerPath(): string {
-  const plat = platform();
-  let relative: string;
+/** Relative path to the Selenium Manager binary for a given platform. */
+export function seleniumManagerRelativePath(plat: NodeJS.Platform = platform()): string {
   switch (plat) {
     case 'darwin':
-      relative = 'bin/macos/selenium-manager';
-      break;
+      return 'bin/macos/selenium-manager';
     case 'win32':
-      relative = 'bin/windows/selenium-manager.exe';
-      break;
+      return 'bin/windows/selenium-manager.exe';
     default:
-      relative = 'bin/linux/selenium-manager';
-      break;
+      return 'bin/linux/selenium-manager';
+  }
+}
+
+/**
+ * The directory where selenium-webdriver is actually installed, via Node's
+ * module resolution from this module. Works under npx, global and local
+ * installs alike. Throws if selenium-webdriver cannot be resolved.
+ */
+export function getSeleniumWebdriverDir(): string {
+  return dirname(requireFromHere.resolve('selenium-webdriver/package.json'));
+}
+
+/**
+ * Build the Selenium Manager path. Both inputs are injectable for testing the
+ * cross-platform logic without the other platforms' binaries being present.
+ */
+export function getSeleniumManagerPath(
+  plat: NodeJS.Platform = platform(),
+  baseDir: string = getSeleniumWebdriverDir(),
+): string {
+  return join(baseDir, seleniumManagerRelativePath(plat));
+}
+
+/** Non-throwing inspection of the Selenium Manager binary, for diagnostics. */
+export function inspectSeleniumManager(): { path: string | null; exists: boolean; executable: boolean } {
+  let path: string;
+  try {
+    path = getSeleniumManagerPath();
+  } catch {
+    // selenium-webdriver itself could not be resolved.
+    return { path: null, exists: false, executable: false };
+  }
+  const exists = existsSync(path);
+  return { path, exists, executable: exists && isExecutableFile(path) };
+}
+
+/** True if the path is a non-empty file that the OS can execute. */
+function isExecutableFile(path: string): boolean {
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile() || stat.size === 0) return false;
+  if (platform() === 'win32') return path.toLowerCase().endsWith('.exe');
+  return (stat.mode & 0o111) !== 0;
+}
+
+/**
+ * Resolve the Selenium Manager binary and verify it exists and is executable.
+ * @throws with the attempted path and a remediation hint otherwise.
+ */
+export function resolveSeleniumManager(): string {
+  let path: string;
+  try {
+    path = getSeleniumManagerPath();
+  } catch (err) {
+    throw new Error(
+      `Could not locate the selenium-webdriver package: ${(err as Error).message}\n`
+      + 'selenium-webdriver appears to be missing — reinstall it (npm install selenium-webdriver).',
+    );
   }
 
-  try {
-    const resolved = join(resolve('node_modules', 'selenium-webdriver'), relative);
-    if (existsSync(resolved)) return resolved;
-  } catch {
-    /* fall through */
+  if (!existsSync(path)) {
+    throw new Error(
+      `Selenium Manager binary not found at: ${path}\n`
+      + 'selenium-webdriver is missing or incompletely installed — reinstall it '
+      + '(e.g. npm install selenium-webdriver, or clear the npx cache).',
+    );
   }
-  return join(process.cwd(), 'node_modules', 'selenium-webdriver', relative);
+
+  if (!isExecutableFile(path)) {
+    throw new Error(
+      `Selenium Manager binary at ${path} is not executable.\n`
+      + 'The selenium-webdriver install may be corrupt — reinstall it.',
+    );
+  }
+
+  return path;
 }
 
 interface ManagerOutput {
@@ -192,10 +264,7 @@ interface ManagerOutput {
  * Returns the reported driver_path. Throws with the captured stderr on failure.
  */
 function runManager(env: NodeJS.ProcessEnv, timeoutMs: number): string {
-  const binary = getSeleniumManagerPath();
-  if (!existsSync(binary)) {
-    throw new Error(`Selenium Manager binary not found at: ${binary}`);
-  }
+  const binary = resolveSeleniumManager();
 
   let stdout: string;
   try {


### PR DESCRIPTION
## Why

In 3.3.0, driver provisioning fails on first use under `npx`:

```
Selenium Manager binary not found at: /node_modules/selenium-webdriver/bin/macos/selenium-manager
```

The leading slash is the tell: the bundled `selenium-manager` was resolved relative to `process.cwd()` (the filesystem root when the MCP server is launched with `cwd=/`), instead of the real `selenium-webdriver` install location. Under `npx`, `selenium-webdriver` lives in the npx cache, so `/node_modules/...` never exists.

## What changed

- **Resolve from the package, not cwd** — `getSeleniumWebdriverDir()` uses `createRequire(import.meta.url).resolve('selenium-webdriver/package.json')`, so the binary is found under npx, global and local installs.
- **Cross-platform sub-path** — pure `seleniumManagerRelativePath(plat)`: `darwin → bin/macos`, `linux → bin/linux`, `win32 → bin/windows/…exe`.
- **Guard** — `resolveSeleniumManager()` verifies the binary exists and is executable, else throws with the attempted path and a reinstall hint.
- **doctor** — new first check shows the resolved Selenium Manager path and whether it is executable, making this class of failure immediately visible.
- **Diagnostic command** — `getDiagnosticCommand()` now points at the resolved path instead of a hardcoded `./node_modules/...`.

## Tests

- `getSeleniumManagerPath`/`seleniumManagerRelativePath` across the 3 platforms (injected platform + base dir, `.exe` on Windows), base defaults to the real install (never root-anchored), and the missing-binary guard.
- doctor checks for resolved/missing/unresolvable manager.
- 94 → **104 tests**, tsc clean. Verified live: `doctor` resolves the real `node_modules/selenium-webdriver/bin/windows/selenium-manager.exe`.

Targets 3.3.1. `package.json` stays at 3.3.0 so the Release workflow performs the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)