### PR TITLE
ci: make release workflow publish to npm via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,10 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: [prepare, build, github-release]
+    # OIDC trusted publishing (same mechanism as publish-npm.yml) — no NPM_TOKEN.
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         working-directory: selenium-mcp-server
@@ -199,7 +203,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: selenium-mcp-server/package-lock.json
@@ -211,8 +215,6 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
   # ============================================


### PR DESCRIPTION
## Why

The Release workflow's `publish-npm` job uses `secrets.NPM_TOKEN` on node 20, which fails with `npm error E404` (the token isn't valid for trusted publishing). Every release therefore needs a **separate manual `publish-npm.yml` dispatch** to actually ship to npm (as happened for 3.3.0, 3.3.1 and 3.3.2).

## What changed

Switch `release.yml`'s `publish-npm` job to the same **OIDC trusted publishing** mechanism `publish-npm.yml` already uses successfully:

- add `permissions: { id-token: write, contents: read }` to the job,
- node `20` → `24`,
- drop `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` — `npm publish` authenticates via OIDC.

A single Release dispatch now does everything in one flow: **bump → tag → GitHub release → npm publish**. `publish-npm.yml` is kept as a manual re-publish button.

## Note

No app code changes; CI only. Verifiable on the next release (3.3.3+): the Release run's "Publish to npm" job should go green and no manual `publish-npm.yml` dispatch is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)